### PR TITLE
Add helper_flask module with ResponseCode and ResponseStatus

### DIFF
--- a/hackathon_project_tracker/helper_flask/__init__.py
+++ b/hackathon_project_tracker/helper_flask/__init__.py
@@ -1,0 +1,1 @@
+from .helper_flask import ResponseCode, ResponseStatus

--- a/hackathon_project_tracker/helper_flask/helper_flask.py
+++ b/hackathon_project_tracker/helper_flask/helper_flask.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic.dataclasses import dataclass
+
+from .pydantic_settings import BaseModel  # trunk-ignore(ruff/TCH001)
+
+
+class ResponseCode(Enum):
+    ACCEPTED_AND_SUCCESSFUL = 200
+    ACCEPTED_WITH_NOTHING_TO_DO = 202
+    FAILURE_WITH_RETRY = 429
+    FAILURE_WITH_NO_RETRY = 405
+
+
+class PydanticConfiguration:
+    arbitrary_types_allowed = True
+
+
+@dataclass(
+    config=PydanticConfiguration,
+)
+class ResponseStatus:
+    response_string: str | None
+    response_code: ResponseCode
+    response_dict: BaseModel | None = None
+
+    def __repr__(
+        self: ResponseStatus,
+    ) -> str:
+        return f"{self.response_code.value} : {self.response_code.name} : {self.response_string}"
+
+    @classmethod
+    def from_response_code(
+        cls: type[ResponseStatus],
+        response_code: ResponseCode,
+    ) -> ResponseStatus:
+        return ResponseStatus(
+            response_string=response_code.name,
+            response_code=response_code,
+        )
+
+    def get_return_response_dict(
+        self: ResponseStatus,
+    ) -> BaseModel:
+        response_dict: BaseModel | None = self.response_dict
+        if response_dict is None:
+            raise AttributeError
+
+        return response_dict
+
+    def get_return_response_with_dict(
+        self: ResponseStatus,
+    ) -> tuple[BaseModel, int]:
+        return self.get_return_response_dict(), self.response_code.value
+
+    def get_return_response_string(
+        self: ResponseStatus,
+    ) -> str:
+        response_string: str | None = self.response_string
+        if response_string is None:
+            raise AttributeError
+
+        return response_string
+
+    def get_return_response_tuple_with_string(
+        self: ResponseStatus,
+    ) -> tuple[str, int]:
+        return self.get_return_response_string(), self.response_code.value

--- a/hackathon_project_tracker/helper_flask/pydantic_settings.py
+++ b/hackathon_project_tracker/helper_flask/pydantic_settings.py
@@ -1,0 +1,11 @@
+from pydantic import (
+    BaseModel as BaseModelPydantic,
+    ConfigDict,
+)
+
+
+class BaseModel(BaseModelPydantic):
+    model_config = ConfigDict(
+        validate_assignment=True,
+        populate_by_name=True,
+    )


### PR DESCRIPTION
This pull request introduces a new helper module for Flask applications, focusing on standardizing API responses. The changes include:

1. Creation of a `ResponseCode` enum to define standard HTTP response codes.
2. Implementation of a `ResponseStatus` dataclass to encapsulate response information, including methods for generating different types of responses.
3. Addition of a custom `BaseModel` class extending Pydantic's `BaseModel` with specific configuration options.
4. Introduction of a `PydanticConfiguration` class to allow arbitrary types in Pydantic models.

These additions provide a structured approach to handling API responses, improving consistency and ease of use across the application.
