### PR TITLE
Add GitHubIssueStateType enum

### DIFF
--- a/hackathon_project_tracker/helper_universal_primitives/__init__.py
+++ b/hackathon_project_tracker/helper_universal_primitives/__init__.py
@@ -1,0 +1,1 @@
+from .universal_github_issue_state import GitHubIssueStateType

--- a/hackathon_project_tracker/helper_universal_primitives/universal_github_issue_state.py
+++ b/hackathon_project_tracker/helper_universal_primitives/universal_github_issue_state.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class GitHubIssueStateType(Enum):
+    OPEN = "open"
+    CLOSED = "closed"


### PR DESCRIPTION
This pull request introduces a new module `helper_universal_primitives` to the hackathon project tracker. It defines an enumeration `GitHubIssueStateType` that represents the possible states of a GitHub issue: "open" and "closed". This addition will help standardize and type-check issue state handling throughout the project.
