### PR TITLE
Add GitHub helper models and utilities

### DIFF
--- a/hackathon_project_tracker/helper_github/__init__.py
+++ b/hackathon_project_tracker/helper_github/__init__.py
@@ -1,0 +1,28 @@
+from .github_issue_state import GitHubIssueStateReasonType, GitHubIssueStateType
+from .helper_github_client import create_repo_path, set_up_client_from_tokens
+from .helper_utils import traverse_markdown_document
+from .model_github_payloads import (
+    GitHubPayloadCommentCreated,
+    GitHubPayloadFork,
+    GitHubPayloadIssueClosed,
+    GitHubPayloadIssueCommentEdited,
+    GitHubPayloadIssueLabeled,
+    GitHubPayloadIssueOpen,
+    GitHubPayloadIssueUnlabeled,
+    GitHubPayloadStarred,
+)
+from .model_github_primitives import (
+    GitHubComment,
+    GitHubFork,
+    GitHubIssue,
+    GitHubLabel,
+    GitHubRepository,
+    GitHubUser,
+)
+from .model_github_security_alert import (
+    GitHubAlert,
+    GitHubAlertSecurityAdvisory,
+    GitHubAlertSecurityAdvisorySeverity,
+    GitHubPayloadAlert,
+    GitHubPayloadAlertContainer,
+)

--- a/hackathon_project_tracker/helper_github/github_issue_state.py
+++ b/hackathon_project_tracker/helper_github/github_issue_state.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class GitHubIssueStateType(Enum):
+    CLOSED = "closed"
+    OPENED = "opened"
+
+
+class GitHubIssueStateReasonType(Enum):
+    COMPLETED = auto()
+    NOT_PLANNED = auto()
+
+    @classmethod
+    def from_github_issue_state_reason(
+        cls: type[GitHubIssueStateReasonType],
+        github_issue_state_reason: str,
+    ) -> GitHubIssueStateReasonType:
+        match github_issue_state_reason:
+
+            case "completed":
+                return GitHubIssueStateReasonType.COMPLETED
+
+            case "not_planned":
+                return GitHubIssueStateReasonType.NOT_PLANNED
+
+            case "reopened":
+                return GitHubIssueStateReasonType.COMPLETED
+
+            case _:
+                error_msg: str = (
+                    f"GitHub: Issue State Reason Type: Null: {github_issue_state_reason}"
+                )
+                raise ValueError(
+                    error_msg,
+                )

--- a/hackathon_project_tracker/helper_github/helper_github_client.py
+++ b/hackathon_project_tracker/helper_github/helper_github_client.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from github import Github
+
+from hackathon_project_tracker import helper_utils
+from hackathon_project_tracker.helper_logging import Severity, log
+
+
+def create_repo_path(
+    tokens: (
+        dict[
+            str,
+            str | None,
+        ]
+        | None
+    ),
+) -> str:
+    tokens = helper_utils.check_tokens(
+        tokens=tokens,
+    )
+    github_owner: str | None = tokens.get(
+        "GITHUB_OWNER",
+        None,
+    )
+    github_repo: str | None = tokens.get(
+        "GITHUB_REPO",
+        None,
+    )
+    if github_owner is None:
+        raise AttributeError
+
+    if github_repo is None:
+        raise AttributeError
+
+    github_repo_path: str = f"{github_owner}/{github_repo}"
+    match len(github_repo_path):
+
+        case 0 | 1:
+            raise AttributeError
+
+        case _:
+            return github_repo_path
+
+
+def set_up_client_from_tokens(
+    tokens: (
+        dict[
+            str,
+            str | None,
+        ]
+        | None
+    ),
+) -> Github:
+    tokens = helper_utils.check_tokens(
+        tokens=tokens,
+    )
+    log(
+        the_log="Setting up client",
+        severity=Severity.DEBUG,
+        file=__file__,
+    )
+    github_owner: str | None = tokens.get(
+        "GITHUB_OWNER",
+        None,
+    )
+    if github_owner is None:
+        raise AttributeError("GITHUB_OWNER is not set")
+
+    github_repo: str | None = tokens.get(
+        "GITHUB_REPO",
+        None,
+    )
+    if github_repo is None:
+        raise AttributeError("GITHUB_REPO is not set")
+
+
+    github_client_id: str | None = tokens.get(
+        "GITHUB_CLIENT_ID",
+        None,
+    )
+    if github_client_id is None:
+        raise AttributeError("GITHUB_CLIENT_ID is not set")
+
+    github_client_secret: str | None = tokens.get(
+        "GITHUB_CLIENT_SECRET",
+        None,
+    )
+    if github_client_secret is None:
+        raise AttributeError("GITHUB_CLIENT_SECRET is not set")
+
+    github_client: Github = Github()
+    github_client.get_oauth_application(
+        client_id=github_client_id,
+        client_secret=github_client_secret,
+    )
+    return github_client

--- a/hackathon_project_tracker/helper_github/helper_utils.py
+++ b/hackathon_project_tracker/helper_github/helper_utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+DEFAULT_GITHUB_PREFIX: str = "GH"
+DEFAULT_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DEFAULT_TIME_ZONE: str = "US/Pacific"
+
+if TYPE_CHECKING:
+    import datetime
+
+
+def add_github_prefix(
+    string_to_prefix: str,
+    github_prefix: str | None = None,
+) -> str:
+    if github_prefix is None:
+        github_prefix = DEFAULT_GITHUB_PREFIX
+
+    return f"{github_prefix}-{string_to_prefix}"
+
+
+def create_timestamp_github(
+    timestamp: datetime.datetime | None,
+) -> str:
+    if timestamp is None:
+        raise AttributeError
+
+    return timestamp.strftime(DEFAULT_TIME_FORMAT)
+
+
+def traverse_markdown_document(
+    node: Any,  # noqa: ANN401
+) -> list[str]:
+    """Marko parses text into a tree representation.
+
+    Starts at the top of the tree and traverses the to the leaves returning a list of all the strings.
+    This allows for more precision when applying regex, since we're applying per content object i.e. heading, paragraph, etc.
+    """
+    children = None
+    try:
+        children = node.children
+
+    except AttributeError:
+        return []
+
+    if children is None:
+        return []
+
+    if isinstance(
+        children,
+        str,
+    ):
+        return [children]
+
+    output: list[str] = []
+    for child in children:
+        if content := traverse_markdown_document(
+            node=child,
+        ):
+            output.extend(content)
+
+    return output

--- a/hackathon_project_tracker/helper_github/model_github_payloads.py
+++ b/hackathon_project_tracker/helper_github/model_github_payloads.py
@@ -1,0 +1,178 @@
+# trunk-ignore-all(ruff/TCH001)
+from __future__ import annotations
+
+import datetime  # trunk-ignore(ruff/TCH003)
+
+from hackathon_project_tracker.helper_logging import Severity, log
+
+from .model_github_primitives import (
+    GitHubComment,
+    GitHubCommentChanges,
+    GitHubDiscussion,
+    GitHubFork,
+    GitHubIssue,
+    GitHubLabel,
+    GitHubOrganization,
+    GitHubRepository,
+    GitHubUser,
+)
+from .pydantic_settings import BaseModel
+
+
+class GitHubPayloadFork(BaseModel):
+    forkee: GitHubFork
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    def validate_response(
+        self: GitHubPayloadFork,
+    ) -> None:
+        log(
+            the_log=f"Successfully parsed the payload with: {self.__class__.__name__}",
+            severity=Severity.DEBUG,
+            file=__file__,
+        )
+
+
+class GitHubPayloadCommentCreated(BaseModel):
+    action: str
+    issue: GitHubIssue
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+    comment: GitHubComment
+
+    def get_github_comment(
+        self: GitHubPayloadCommentCreated,
+    ) -> GitHubComment:
+        if github_comment := self.comment:
+            return github_comment
+
+        raise AttributeError
+
+    def get_github_issue(
+        self: GitHubPayloadCommentCreated,
+    ) -> GitHubIssue:
+        if github_issue := self.issue:
+            return github_issue
+
+        raise AttributeError
+
+    def get_github_user(
+        self: GitHubPayloadCommentCreated,
+    ) -> GitHubUser:
+        if github_user := self.sender:
+            return github_user
+
+        raise AttributeError
+
+
+class GitHubPayloadDiscussionCommentEdited(BaseModel):
+    action: str
+    changes: GitHubCommentChanges
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+    comment: GitHubComment
+    discussion: GitHubDiscussion
+
+    def get_github_issue(
+        self: GitHubPayloadDiscussionCommentEdited,
+    ) -> GitHubIssue:
+        raise TypeError
+
+
+class GitHubPayloadIssueCommentEdited(BaseModel):
+    action: str
+    changes: GitHubCommentChanges
+    issue: GitHubIssue
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+    comment: GitHubComment
+
+    def get_github_issue(
+        self: GitHubPayloadIssueCommentEdited,
+    ) -> GitHubIssue:
+        if github_issue := self.issue:
+            return github_issue
+
+        raise AttributeError
+
+
+class GitHubPayloadIssueClosed(BaseModel):
+    action: str
+    issue: GitHubIssue
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    def get_github_issue(
+        self: GitHubPayloadIssueClosed,
+    ) -> GitHubIssue:
+        if github_issue := self.issue:
+            return github_issue
+
+        raise AttributeError
+
+
+class GitHubPayloadIssueLabeled(BaseModel):
+    action: str
+    issue: GitHubIssue
+    label: GitHubLabel
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    def get_github_issue(
+        self: GitHubPayloadIssueLabeled,
+    ) -> GitHubIssue:
+        if github_issue := self.issue:
+            return github_issue
+
+        raise AttributeError
+
+
+class GitHubPayloadIssueUnlabeled(BaseModel):
+    action: str
+    issue: GitHubIssue
+    label: GitHubLabel
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    def get_github_issue(
+        self: GitHubPayloadIssueUnlabeled,
+    ) -> GitHubIssue:
+        if github_issue := self.issue:
+            return github_issue
+
+        raise AttributeError
+
+
+class GitHubPayloadIssueOpen(BaseModel):
+    action: str
+    issue: GitHubIssue
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    def get_github_issue(
+        self: GitHubPayloadIssueOpen,
+    ) -> GitHubIssue:
+        raise TypeError
+
+    def validate(
+        self: GitHubPayloadIssueOpen,
+    ) -> bool:
+        return self.action == "opened"
+
+
+class GitHubPayloadStarred(BaseModel):
+    action: str
+    repository: GitHubRepository
+    organization: GitHubOrganization
+    sender: GitHubUser
+
+    starred_at: datetime.datetime | None = None

--- a/hackathon_project_tracker/helper_github/model_github_primitives.py
+++ b/hackathon_project_tracker/helper_github/model_github_primitives.py
@@ -1,0 +1,614 @@
+# trunk-ignore-all(trunk/ignore-does-nothing)
+from __future__ import annotations
+
+import datetime  # trunk-ignore(ruff/TCH003)
+from typing import Any
+
+from pydantic import Field
+
+from hackathon_project_tracker.helper_universal_primitives import GitHubIssueStateType
+from hackathon_project_tracker.helper_utils import GitHubIssueCode, GitHubIssueCodeTitle
+
+from .pydantic_settings import BaseModel
+
+
+class GitHubOrganization(BaseModel):
+    avatar_url: str | None
+    description: str | None
+    events_url: str | None
+    hooks_url: str | None
+    id: int | None
+    issues_url: str | None
+    login: str | None
+    members_url: str | None
+    node_id: str | None
+    public_members_url: str | None
+    repos_url: str | None
+    url: str | None
+
+
+class GitHubReactions(BaseModel):
+    plus_one: int | None = Field(
+        alias="+1",
+        default_factory=int,
+    )
+    minus_one: int | None = Field(
+        alias="-1",
+        default_factory=int,
+    )
+    confused: int | None
+    eyes: int | None
+    heart: int | None
+    hooray: int | None
+    laugh: int | None
+    rocket: int | None
+    total_count: int | None
+    url: str | None
+
+
+class GitHubLicense(BaseModel):
+    key: str | None
+    name: str | None
+    node_id: str | None
+    spdx_id: str | None
+    url: Any | None
+
+
+class GitHubRepositoryOwner(BaseModel):
+    avatar_url: str | None
+    events_url: str | None
+    followers_url: str | None
+    following_url: str | None
+    gists_url: str | None
+    gravatar_id: str | None
+    html_url: str | None
+    id: int | None
+    login: str | None
+    node_id: str | None
+    organizations_url: str | None
+    received_events_url: str | None
+    repos_url: str | None
+    site_admin: bool | None
+    starred_url: str | None
+    subscriptions_url: str | None
+    type: str | None
+    url: str | None
+
+
+class GitHubRepository(BaseModel):
+    allow_forking: bool | None
+    archive_url: str | None
+    archived: bool | None
+    assignees_url: str | None
+    blobs_url: str | None
+    branches_url: str | None
+    clone_url: str | None
+    collaborators_url: str | None
+    comments_url: str | None
+    commits_url: str | None
+    compare_url: str | None
+    contents_url: str | None
+    contributors_url: str | None
+    created_at: datetime.datetime | None
+    default_branch: str | None
+    deployments_url: str | None
+    description: str | None
+    disabled: bool | None
+    downloads_url: str | None
+    events_url: str | None
+    fork: bool | None
+    forks: int | None
+    forks_count: int | None
+    forks_url: str | None
+    full_name: str | None
+    git_commits_url: str | None
+    git_refs_url: str | None
+    git_tags_url: str | None
+    git_url: str | None
+    has_downloads: bool | None
+    has_issues: bool | None
+    has_pages: bool | None
+    has_projects: bool | None
+    has_wiki: bool | None
+    homepage: str | None
+    hooks_url: str | None
+    html_url: str | None
+    id: int | None
+    is_template: bool | None
+    issue_comment_url: str | None
+    issue_events_url: str | None
+    issues_url: str | None
+    keys_url: str | None
+    labels_url: str | None
+    language: Any | None
+    languages_url: str | None
+    license: GitHubLicense | None
+    merges_url: str | None
+    milestones_url: str | None
+    mirror_url: Any | None
+    name: str | None
+    node_id: str | None
+    notifications_url: str | None
+    open_issues: int | None
+    open_issues_count: int | None
+    owner: GitHubRepositoryOwner | None
+    private: bool | None
+    pulls_url: str | None
+    pushed_at: datetime.datetime | None
+    releases_url: str | None
+    size: int | None
+    ssh_url: str | None
+    stargazers_count: int | None
+    stargazers_url: str | None
+    statuses_url: str | None
+    subscribers_url: str | None
+    subscription_url: str | None
+    svn_url: str | None
+    tags_url: str | None
+    teams_url: str | None
+    topics: list[str] | None
+    trees_url: str | None
+    updated_at: datetime.datetime | None
+    url: str | None
+    visibility: str | None
+    watchers: int | None
+    watchers_count: int | None
+    web_commit_signoff_required: bool | None
+
+    def get_full_name(
+        self: GitHubRepository,
+    ) -> str:
+        if github_full_name := self.full_name:
+            return github_full_name
+
+        raise AttributeError
+
+    def get_name(
+        self: GitHubRepository,
+    ) -> str:
+        if github_name := self.name:
+            return github_name
+
+        raise AttributeError
+
+
+class GitHubUser(BaseModel):
+    avatar_url: str | None
+    events_url: str | None
+    followers_url: str | None
+    following_url: str | None
+    gists_url: str | None
+    gravatar_id: str | None
+    html_url: str | None
+    login: str | None
+    node_id: str | None
+    organizations_url: str | None
+    received_events_url: str | None
+    repos_url: str | None
+    starred_url: str | None
+    subscriptions_url: str | None
+    type: str | None
+    url: str | None
+    id: int | None = None
+    site_admin: bool | None = None
+
+    def get_node_id(
+        self: GitHubUser,
+    ) -> str:
+        if github_node_id := self.node_id:
+            return github_node_id
+
+        raise AttributeError
+
+    def get_username(
+        self: GitHubUser,
+    ) -> str:
+        if github_username := self.login:
+            return github_username
+
+        raise AttributeError
+
+    def is_bot(
+        self: GitHubUser,
+    ) -> bool:
+        match self.type:
+            case "Bot":
+                return True
+
+            case "User":
+                return False
+
+            case "Organization":
+                return False
+
+            case _:
+                raise ValueError
+
+    def create_front_sender_handle(
+        self: GitHubUser,
+    ) -> str:
+        if github_login := self.login:
+            return f"GH-{github_login}"
+
+        raise AttributeError
+
+    def get_user(
+        self: GitHubUser,
+    ) -> str:
+        if github_user := self.login:
+            return github_user
+
+        raise AttributeError
+
+
+class GitHubFork(BaseModel):
+    id: int | None
+    node_id: str | None
+    name: str | None
+    full_name: str | None
+    private: bool | None
+    owner: GitHubUser | None
+    html_url: str | None
+    description: str | None
+    fork: bool | None
+    url: str | None
+    forks_url: str | None
+    keys_url: str | None
+    collaborators_url: str | None
+    teams_url: str | None
+    hooks_url: str | None
+    issue_events_url: str | None
+    events_url: str | None
+    assignees_url: str | None
+    branches_url: str | None
+    tags_url: str | None
+    blobs_url: str | None
+    git_tags_url: str | None
+    git_refs_url: str | None
+    trees_url: str | None
+    statuses_url: str | None
+    languages_url: str | None
+    stargazers_url: str | None
+    contributors_url: str | None
+    subscribers_url: str | None
+    subscription_url: str | None
+    commits_url: str | None
+    git_commits_url: str | None
+    comments_url: str | None
+    issue_comment_url: str | None
+    contents_url: str | None
+    compare_url: str | None
+    merges_url: str | None
+    archive_url: str | None
+    downloads_url: str | None
+    issues_url: str | None
+    pulls_url: str | None
+    milestones_url: str | None
+    notifications_url: str | None
+    labels_url: str | None
+    releases_url: str | None
+    deployments_url: str | None
+    created_at: datetime.datetime | None
+    updated_at: datetime.datetime | None
+    pushed_at: datetime.datetime | None
+    git_url: str | None
+    ssh_url: str | None
+    clone_url: str | None
+    svn_url: str | None
+    homepage: str | None
+    size: int | None
+    stargazers_count: int | None
+    watchers_count: int | None
+    has_issues: bool | None
+    has_projects: bool | None
+    has_downloads: bool | None
+    has_wiki: bool | None
+    has_pages: bool | None
+    has_discussions: bool | None
+    forks_count: int | None
+    archived: bool | None
+    disabled: bool | None
+    open_issues_count: int | None
+    license: GitHubLicense | None
+    allow_forking: bool | None
+    is_template: bool | None
+    web_commit_signoff_required: bool | None
+    topics: list[str] | None
+    visibility: str | None
+    forks: int | None
+    open_issues: int | None
+    watchers: int | None
+    default_branch: str | None
+    public: bool | None
+    language: None
+    mirror_url: None
+
+
+class GitHubDiscussionCategory(BaseModel):
+    id: int
+    node_id: str
+    repository_id: int
+    emoji: str
+    name: str
+    description: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    slug: str
+    is_answerable: bool
+
+
+class GitHubDiscussion(BaseModel):
+    repository_url: str
+    category: GitHubDiscussionCategory
+    answer_html_url: None
+    answer_chosen_at: datetime.datetime
+    answer_chosen_by: None
+    html_url: str
+    id: int
+    node_id: str
+    number: int
+    title: str
+    user: GitHubUser
+    state: str
+    state_reason: None
+    locked: bool
+    comments: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    author_association: str
+    active_lock_reason: None
+    body: str
+    reactions: GitHubReactions
+    timeline_url: str
+
+
+class GitHubComment(BaseModel):
+    user: GitHubUser
+    performed_via_github_app: bool | None
+    url: str | None = None
+    html_url: str | None = None
+    issue_url: str | None = None
+    id: int | None = None
+    node_id: str | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    author_association: str | None = None
+    body: str | None = None
+    reactions: GitHubReactions | None = None
+
+    def get_body(
+        self: GitHubComment,
+    ) -> str:
+        if github_body := self.body:
+            return github_body
+
+        raise AttributeError
+
+    def get_created_at(
+        self: GitHubComment,
+    ) -> datetime.datetime:
+        if github_created_at := self.created_at:
+            return github_created_at
+
+        raise AttributeError
+
+    def get_node_id(
+        self: GitHubComment,
+    ) -> str:
+        if github_node_id := self.node_id:
+            return github_node_id
+
+        raise AttributeError
+
+    def get_url_html(
+        self: GitHubComment,
+    ) -> str:
+        if github_url := self.html_url:
+            return github_url
+
+        raise AttributeError
+
+    def get_user(
+        self: GitHubComment,
+    ) -> GitHubUser:
+        if github_user := self.user:
+            return github_user
+
+        raise AttributeError
+
+    def create_body_with_url(
+        self: GitHubComment,
+    ) -> str:
+        github_url: str = self.get_url_html()
+        github_body: str = self.get_body()
+        github_body_with_url: str = f"{github_url}\n\n{github_body}"
+        return github_body_with_url
+
+    def is_from_bot(
+        self: GitHubComment,
+    ) -> bool:
+        return self.user.is_bot()
+
+
+class GitHubCommentChangesBody(BaseModel):
+    body_from: str | None = None
+
+
+class GitHubCommentChanges(BaseModel):
+    body: GitHubCommentChangesBody | None = None
+
+
+class GitHubLabel(BaseModel):
+    id: int | None = None
+    node_id: str | None = None
+    url: str | None = None
+    name: str | None = None
+    color: str | None = None
+    default: bool | None = None
+    description: str | None = None
+
+    def get_id(
+        self: GitHubLabel,
+    ) -> int:
+        if github_label_id := self.id:
+            return github_label_id
+
+        raise AttributeError
+
+    def get_name(
+        self: GitHubLabel,
+    ) -> str:
+        if github_name := self.name:
+            return github_name
+
+        raise AttributeError
+
+    def get_node_id(
+        self: GitHubLabel,
+    ) -> str:
+        if github_node_id := self.node_id:
+            return github_node_id
+
+        raise AttributeError
+
+    def is_bug(
+        self: GitHubLabel,
+    ) -> bool:
+        github_name = self.get_name()
+        return github_name == "Bug"
+
+
+class GitHubIssue(BaseModel):
+    active_lock_reason: Any | None
+    assignee: GitHubUser | None
+    assignees: list[GitHubUser] | None
+    author_association: str | None
+    body: str | None
+    closed_at: datetime.datetime | None
+    comments: int | None
+    comments_url: str | None
+    created_at: datetime.datetime | None
+    events_url: str | None
+    html_url: str | None
+    id: int | None
+    labels: list[GitHubLabel] | None
+    labels_url: str | None
+    locked: bool | None
+    milestone: Any | None
+    node_id: str | None
+    number: int
+    performed_via_github_app: Any | None
+    reactions: GitHubReactions | None
+    repository_url: str | None
+    state: str | None
+    state_reason: str | None
+    timeline_url: str | None
+    title: str | None
+    updated_at: datetime.datetime | None
+    url: str | None
+    user: GitHubUser
+
+    def get_body(
+        self: GitHubIssue,
+    ) -> str:
+        if github_body := self.body:
+            return github_body
+
+        raise AttributeError
+
+    def get_created_at(
+        self: GitHubIssue,
+    ) -> datetime.datetime:
+        if github_created_at := self.created_at:
+            return github_created_at
+
+        raise AttributeError
+
+    def get_github_issue_code(
+        self: GitHubIssue,
+    ) -> GitHubIssueCode:
+        if self.number:
+            return GitHubIssueCode.from_int(
+                github_issue_number=self.number,
+            )
+
+        raise AttributeError
+
+    def get_labels(
+        self: GitHubIssue,
+    ) -> list[GitHubLabel]:
+        if github_labels := self.labels:
+            return github_labels
+
+        raise AttributeError
+
+    def get_node_id(
+        self: GitHubIssue,
+    ) -> str:
+        if github_node_id := self.node_id:
+            return github_node_id
+
+        raise AttributeError
+
+    def get_github_state(
+        self: GitHubIssue,
+    ) -> GitHubIssueStateType:
+        if github_state := self.state:
+            return GitHubIssueStateType(github_state)
+
+        raise AttributeError
+
+    def get_state_reason(
+        self: GitHubIssue,
+    ) -> str:
+        if github_state_reason := self.state_reason:
+            return github_state_reason
+
+        raise AttributeError
+
+    def get_title(
+        self: GitHubIssue,
+    ) -> str:
+        if github_title := self.title:
+            return github_title
+
+        raise AttributeError
+
+    def get_url_html(
+        self: GitHubIssue,
+    ) -> str:
+        if github_url := self.html_url:
+            return github_url
+
+        raise AttributeError
+
+    def get_user(
+        self: GitHubIssue,
+    ) -> GitHubUser:
+        if github_user := self.user:
+            return github_user
+
+        raise AttributeError
+
+    def create_body_with_url(
+        self: GitHubIssue,
+    ) -> str:
+        github_url: str = self.get_url_html()
+        github_body: str = self.get_body()
+        github_body_with_url: str = f"{github_url}\n\n{github_body}"
+        return github_body_with_url
+
+    def get_github_issue_code_title(
+        self: GitHubIssue,
+    ) -> GitHubIssueCodeTitle:
+        title: str = self.get_title()
+        github_issue_code: GitHubIssueCode = self.get_github_issue_code()
+        return GitHubIssueCodeTitle.from_title_and_github_issue_code(
+            title=title,
+            github_issue_code=github_issue_code,
+        )
+
+    def is_from_bot(
+        self: GitHubIssue,
+    ) -> bool:
+        return self.user.is_bot()

--- a/hackathon_project_tracker/helper_github/model_github_security_alert.py
+++ b/hackathon_project_tracker/helper_github/model_github_security_alert.py
@@ -1,0 +1,211 @@
+# trunk-ignore-all(trunk/ignore-does-nothing)
+from __future__ import annotations
+
+import datetime  # trunk-ignore(ruff/TCH003)
+from enum import Enum
+
+from .model_github_primitives import (
+    GitHubOrganization,  # trunk-ignore(ruff/TCH001)
+    GitHubRepository,  # trunk-ignore(ruff/TCH001)
+    GitHubUser,  # trunk-ignore(ruff/TCH001)
+)
+from .pydantic_settings import BaseModel
+
+
+class GitHubPackage(BaseModel):
+    ecosystem: str | None
+    name: str | None
+
+
+class GitHubAlertSecurityAdvisorySeverity(Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class GitHubAlertSecurityAdvisoryCvss(BaseModel):
+    vector_string: str | None
+    score: float | None
+
+
+class GitHubAlertSecurityAdvisoryCwe(BaseModel):
+    cwe_id: str | None
+    name: str | None
+
+
+class GitHubAlertSecurityAdvisoryIdentifier(BaseModel):
+    value: str | None
+    type: str | None
+
+
+class GitHubAlertSecurityAdvisoryReference(BaseModel):
+    url: str | None
+
+
+class GitHubVulnerabilityFirstPatchedVersion(BaseModel):
+    identifier: str | None
+
+
+class GitHubVulnerability(BaseModel):
+    package: GitHubPackage | None
+    severity: str | None
+    vulnerable_version_range: str | None
+    first_patched_version: GitHubVulnerabilityFirstPatchedVersion | None
+
+
+class GitHubAlertSecurityAdvisory(BaseModel):
+    ghsa_id: str | None
+    cve_id: str | None
+    summary: str | None
+    description: str | None
+    severity: str | None
+    identifiers: list[GitHubAlertSecurityAdvisoryIdentifier] | None
+    references: list[GitHubAlertSecurityAdvisoryReference] | None
+    published_at: datetime.datetime | None
+    updated_at: datetime.datetime | None
+    withdrawn_at: None
+    vulnerabilities: list[GitHubVulnerability] | None
+    cvss: GitHubAlertSecurityAdvisoryCvss | None
+    cwes: list[GitHubAlertSecurityAdvisoryCwe] | None
+
+    def get_description(
+        self: GitHubAlertSecurityAdvisory,
+    ) -> str:
+        if github_description := self.description:
+            return github_description
+
+        raise AttributeError
+
+    def get_ghsa_id(
+        self: GitHubAlertSecurityAdvisory,
+    ) -> str:
+        if github_ghsa_id := self.ghsa_id:
+            return github_ghsa_id
+
+        raise AttributeError
+
+    def get_summary(
+        self: GitHubAlertSecurityAdvisory,
+    ) -> str:
+        if github_summary := self.summary:
+            return github_summary
+
+        raise AttributeError
+
+    def get_severity(
+        self: GitHubAlertSecurityAdvisory,
+    ) -> str:
+        if github_severity := self.severity:
+            return github_severity
+
+        raise AttributeError
+
+
+class GitHubAlertDependency(BaseModel):
+    package: GitHubPackage | None
+    manifest_path: str | None
+    scope: str | None
+
+
+class GitHubAlert(BaseModel):
+    number: int | None
+    state: str | None
+    created_at: datetime.datetime | None
+    dismissed_comment: None = None
+    dependency: GitHubAlertDependency | None = None
+    security_advisory: GitHubAlertSecurityAdvisory | None = None
+    security_vulnerability: GitHubVulnerability | None = None
+    url: str | None = None
+    html_url: str | None = None
+    updated_at: datetime.datetime | None = None
+    dismissed_at: datetime.datetime | None = None
+    dismissed_by: str | None = None
+    dismissed_reason: str | None = None
+    fixed_at: datetime.datetime | None = None
+    auto_dismissed_at: datetime.datetime | None = None
+    id: int | None = None
+    node_id: str | None = None
+    affected_range: str | None = None
+    affected_package_name: str | None = None
+    external_reference: str | None = None
+    external_identifier: str | None = None
+    ghsa_id: str | None = None
+    severity: str | None = None
+    fixed_in: str | None = None
+
+    def get_external_reference(
+        self: GitHubAlert,
+    ) -> str:
+        if external_reference := self.external_reference:
+            return external_reference
+
+        raise AttributeError
+
+    def get_ghsa_id(
+        self: GitHubAlert,
+    ) -> str:
+        if github_ghsa_id := self.ghsa_id:
+            return github_ghsa_id
+
+        raise AttributeError
+
+    def get_html_url(
+        self: GitHubAlert,
+    ) -> str:
+        if github_html_url := self.html_url:
+            return github_html_url
+
+        raise AttributeError
+
+    def get_security_advisory(
+        self: GitHubAlert,
+    ) -> GitHubAlertSecurityAdvisory:
+        if github_security_advisory := self.security_advisory:
+            return github_security_advisory
+
+        raise AttributeError
+
+
+class GitHubPayloadAlert(BaseModel):
+    action: str | None
+    alert: GitHubAlert | None
+    repository: GitHubRepository | None
+    organization: GitHubOrganization | None
+    sender: GitHubUser | None
+
+    def get_action(
+        self: GitHubPayloadAlert,
+    ) -> str:
+        if github_action := self.action:
+            return github_action
+
+        raise AttributeError
+
+    def get_alert(
+        self: GitHubPayloadAlert,
+    ) -> GitHubAlert:
+        if github_alert := self.alert:
+            return github_alert
+
+        raise AttributeError
+
+    def get_repository(
+        self: GitHubPayloadAlert,
+    ) -> GitHubRepository:
+        if github_repository := self.repository:
+            return github_repository
+
+        raise AttributeError
+
+
+class GitHubPayloadAlertContainer(BaseModel):
+    payload: GitHubPayloadAlert | None
+
+    def get_payload(
+        self: GitHubPayloadAlertContainer,
+    ) -> GitHubPayloadAlert:
+        if github_payload := self.payload:
+            return github_payload
+
+        raise AttributeError

--- a/hackathon_project_tracker/helper_github/pydantic_settings.py
+++ b/hackathon_project_tracker/helper_github/pydantic_settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import datetime
+
+from pydantic import (
+    BaseModel as BaseModelPydantic,
+    ConfigDict,
+    FieldSerializationInfo,
+    field_serializer,
+)
+
+from .helper_utils import create_timestamp_github
+
+
+class BaseModel(BaseModelPydantic):
+    model_config = ConfigDict(
+        validate_assignment=True,
+        populate_by_name=True,
+    )
+
+    @field_serializer(  # trunk-ignore(mypy/misc)
+        "answer_chosen_at",
+        "closed_at",
+        "created_at",
+        "pushed_at",
+        "timestamp_conversation",
+        "timestamp_tagged",
+        "updated_at",
+        check_fields=False,
+    )
+    def serialize_timestamp(
+        self: BaseModelPydantic,
+        timestamp: datetime.datetime | None,
+        _info: FieldSerializationInfo,
+    ) -> str | None:
+        del _info
+        if timestamp is None:
+            return None
+
+        return create_timestamp_github(
+            timestamp=timestamp,
+        )


### PR DESCRIPTION
This pull request introduces a new `helper_github` module to the `hackathon_project_tracker` package. The module provides various utilities and models for interacting with GitHub's API and handling GitHub-related data. Here's a summary of the changes:

1. Added GitHub-specific models for various entities such as repositories, users, issues, comments, and security alerts.
2. Implemented utility functions for handling GitHub-specific data, including timestamp formatting and markdown document traversal.
3. Created enums for GitHub issue states and security advisory severities.
4. Added a custom Pydantic BaseModel with configuration for GitHub-specific serialization.
5. Implemented helper functions for setting up GitHub clients and creating repository paths.
6. Added models for handling GitHub webhook payloads for various events like issue creation, comments, and security alerts.

These additions provide a structured way to work with GitHub data and API responses, making it easier to integrate GitHub functionality into the hackathon project tracker.
